### PR TITLE
Enable counter with define and avoid pointer increment with float

### DIFF
--- a/median_of_medians.h
+++ b/median_of_medians.h
@@ -318,7 +318,7 @@ namespace median {
 
         //iter placeit = begin + 10;
 
-        iter pivot = begin + ratio * (placeit - begin);
+        iter pivot = begin + static_cast<size_t>(ratio * (placeit - begin));
         kth_element<Partitioner>(begin, pivot, placeit, less);
         //std::iter_swap(placeit - 1, end - 1);
 

--- a/quickmerge_worst_case.h
+++ b/quickmerge_worst_case.h
@@ -1195,7 +1195,9 @@ void sort_hybrid(iter begin, iter end, Compare less) {
 #endif
             //pivot = median::median_of_medians_partition_ninther<Partitioner, iter, Compare>(begin, end, 0.5, less);
 
+#ifdef PARTIAL_SORT_COUNT	    
             partial_sort_count++;
+#endif
 
 
 
@@ -1332,7 +1334,9 @@ void sort_hybrid_Mo3(iter begin, iter end, Compare less) {
 #endif
             //pivot = median::median_of_medians_partition_ninther<Partitioner, iter, Compare>(begin, end, 0.5, less);
 
+#ifdef PARTIAL_SORT_COUNT	    
             partial_sort_count++;
+#endif
 
 
             pivot = partition::Stl_partition_median_of_medians_of_3_5_left_right<true, iter, Compare>::partition(begin, end, less, inner_array, pivot_width);


### PR DESCRIPTION
Hello,

The benchmark script uses the variable partial_sort_count which is accessed the sorting algorithm. This request disables access to partial_sort_count by default.

This request casts a float value to size_t before adding the value to a pointer. If float is added to a pointer, some compiler do not compile the code.